### PR TITLE
Fix service time tracking: use max instead of min for last service times

### DIFF
--- a/openmines/src/dump_site.py
+++ b/openmines/src/dump_site.py
@@ -53,8 +53,8 @@ class DumpSite:
         self.last_service_done_time = 0  # 上一次服务End时间
 
     def update_service_time(self):
-        self.last_service_time = min([dumper.last_service_time for dumper in self.dumper_list])
-        self.last_service_done_time = min([dumper.last_service_done_time for dumper in self.dumper_list])
+        self.last_service_time = max([dumper.last_service_time for dumper in self.dumper_list])
+        self.last_service_done_time = max([dumper.last_service_done_time for dumper in self.dumper_list])
 
     def set_env(self, env:simpy.Environment):
         self.env = env

--- a/openmines/src/load_site.py
+++ b/openmines/src/load_site.py
@@ -159,8 +159,8 @@ class LoadSite:
         self.last_service_done_time = 0  # 上一次服务End时间
 
     def update_service_time(self):
-        self.last_service_time = min([shovel.last_service_time for shovel in self.shovel_list])
-        self.last_service_done_time = min([shovel.last_service_done_time for shovel in self.shovel_list])
+        self.last_service_time = max([shovel.last_service_time for shovel in self.shovel_list])
+        self.last_service_done_time = max([shovel.last_service_done_time for shovel in self.shovel_list])
 
     def set_env(self, env:simpy.Environment):
         self.env = env


### PR DESCRIPTION
## Summary
Fixed incorrect aggregation logic in service time tracking for both dump sites and load sites. Changed from using `min()` to `max()` when updating the last service times across multiple equipment units.

## Key Changes
- **dump_site.py**: Updated `update_service_time()` to use `max()` instead of `min()` for both `last_service_time` and `last_service_done_time` across all dumpers
- **load_site.py**: Updated `update_service_time()` to use `max()` instead of `min()` for both `last_service_time` and `last_service_done_time` across all shovels

## Implementation Details
The change corrects the logic for tracking when a site was last serviced. Using `max()` ensures we capture the most recent service time across all equipment units at a site, rather than the earliest. This is the correct semantic for "last service time" - we want to know when the site was most recently in use, not when it was least recently used.

This fix applies consistently across both dump sites (which track dumper equipment) and load sites (which track shovel equipment).

https://claude.ai/code/session_01778peCkoK14CzU2ZpD6R5r