### PR TITLE
feat: add 4 new dispatch algorithms (LP, MPC, DualLP, Smart)

### DIFF
--- a/openmines/src/dispatch_algorithms/dual_lp_dispatcher.py
+++ b/openmines/src/dispatch_algorithms/dual_lp_dispatcher.py
@@ -1,0 +1,360 @@
+"""
+DualLPDispatcher: LPDispatcher enhanced with shadow prices and regret tracking.
+
+Improvements over LPDispatcher:
+1. Uses LP dual variables (shadow prices) to dynamically value each site's
+   marginal capacity — high shadow price = binding constraint = avoid overloading
+2. Tracks actual vs LP-target truck allocation per route and adjusts bias
+   dynamically (regret-based) instead of using a fixed discount
+3. Shadow prices are re-computed on each LP re-solve (every 15 min)
+"""
+from __future__ import annotations
+import numpy as np
+from scipy.optimize import linprog
+
+from openmines.src.dispatcher import BaseDispatcher
+from openmines.src.load_site import LoadSite
+from openmines.src.dump_site import DumpSite
+
+
+class DualLPDispatcher(BaseDispatcher):
+    def __init__(self, reoptimize_interval=15):
+        super().__init__()
+        self.name = "DualLPDispatcher"
+        self.reoptimize_interval = reoptimize_interval
+
+        # LP state
+        self._solved = False
+        self._last_solve_time = -999
+        self._truck_route = {}    # truck_name → (ls_idx, ds_idx)
+        self._num_ls = 0
+        self._num_ds = 0
+
+        # Shadow prices (dual variables)
+        self._ls_shadow = {}      # ls_idx → shadow price (marginal value of capacity)
+        self._ds_shadow = {}      # ds_idx → shadow price
+
+        # Regret tracking: actual dispatches vs LP target per route
+        self._route_target = {}   # (ls, ds) → target fraction
+        self._route_actual = {}   # (ls, ds) → actual dispatch count
+        self._total_dispatches = 0
+
+    # ──────────────────────────────────────────────────────
+    # LP Solver with Dual Extraction
+    # ──────────────────────────────────────────────────────
+
+    def _cycle_time(self, cap, speed, ls, ls_idx, ds, ds_idx, mine):
+        l2d = mine.road.l2d_road_matrix[ls_idx, ds_idx]
+        d2l = mine.road.d2l_road_matrix[ls_idx, ds_idx]
+        travel = 60.0 * (l2d + d2l) / speed
+        active = [s for s in ls.shovel_list if not s.repair]
+        if not active:
+            return float('inf')
+        prod = sum(s.shovel_tons / s.shovel_cycle_time for s in active)
+        load_time = cap / (prod / len(active))
+        unload = ds.dumper_list[0].dump_time if ds.dumper_list else 1.0
+        return travel + load_time + unload
+
+    def _solve_lp(self, mine):
+        trucks = mine.trucks
+        NL = len(mine.load_sites)
+        ND = len(mine.dump_sites)
+        NT = len(trucks)
+        NR = NL * ND
+        NV = NT * NR
+        self._num_ls = NL
+        self._num_ds = ND
+
+        throughput = np.zeros(NV)
+        trip_rate = np.zeros(NV)
+
+        for i, truck in enumerate(trucks):
+            for j in range(NL):
+                for k in range(ND):
+                    r = j * ND + k
+                    idx = i * NR + r
+                    ct = self._cycle_time(
+                        truck.truck_capacity, truck.truck_speed,
+                        mine.load_sites[j], j, mine.dump_sites[k], k, mine
+                    )
+                    if ct > 0 and ct != float('inf'):
+                        throughput[idx] = truck.truck_capacity / ct
+                        trip_rate[idx] = 1.0 / ct
+
+        c = -throughput
+
+        A_eq = np.zeros((NT, NV))
+        for i in range(NT):
+            A_eq[i, i * NR:(i + 1) * NR] = 1.0
+        b_eq = np.ones(NT)
+
+        A_ub_list = []
+        b_ub_list = []
+
+        # Load site constraints (first NL rows)
+        for j in range(NL):
+            ls = mine.load_sites[j]
+            active = [s for s in ls.shovel_list if not s.repair]
+            prod = sum(s.shovel_tons / s.shovel_cycle_time for s in active) if active else 0.01
+            row = np.zeros(NV)
+            for i in range(NT):
+                for k in range(ND):
+                    row[i * NR + j * ND + k] = throughput[i * NR + j * ND + k]
+            A_ub_list.append(row)
+            b_ub_list.append(prod)
+
+        # Dump site constraints (next ND rows)
+        for k in range(ND):
+            ds = mine.dump_sites[k]
+            n_dumpers = len(ds.dumper_list)
+            unload = ds.dumper_list[0].dump_time if ds.dumper_list else 1.0
+            row = np.zeros(NV)
+            for i in range(NT):
+                for j in range(NL):
+                    row[i * NR + j * ND + k] = trip_rate[i * NR + j * ND + k]
+            A_ub_list.append(row)
+            b_ub_list.append(n_dumpers / unload)
+
+        A_ub = np.array(A_ub_list)
+        b_ub = np.array(b_ub_list)
+        bounds = [(0, 1)] * NV
+
+        result = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
+                         bounds=bounds, method='highs')
+
+        if result.success:
+            x = result.x
+            # Extract shadow prices (dual variables for inequality constraints)
+            duals = result.ineqlin.marginals  # negative = binding, magnitude = value
+            for j in range(NL):
+                self._ls_shadow[j] = abs(duals[j])  # higher = more congested
+            for k in range(ND):
+                self._ds_shadow[k] = abs(duals[NL + k])
+        else:
+            x = np.ones(NV) / NR
+            for j in range(NL):
+                self._ls_shadow[j] = 0.0
+            for k in range(ND):
+                self._ds_shadow[k] = 0.0
+
+        # Extract truck assignments and route targets
+        self._truck_route = {}
+        route_alloc = {}  # (j, k) → total allocation weight
+
+        for i, truck in enumerate(trucks):
+            allocs = x[i * NR:(i + 1) * NR]
+            best_r = np.argmax(allocs)
+            j = best_r // ND
+            k = best_r % ND
+            self._truck_route[truck.name] = (j, k)
+
+            # Track LP allocation across all routes
+            for r in range(NR):
+                jj, kk = r // ND, r % ND
+                route_alloc[(jj, kk)] = route_alloc.get((jj, kk), 0.0) + allocs[r]
+
+        total_alloc = sum(route_alloc.values())
+        if total_alloc > 0:
+            self._route_target = {rte: v / total_alloc for rte, v in route_alloc.items()}
+        else:
+            self._route_target = {}
+
+        # Initialize actual counts if first solve
+        if not self._route_actual:
+            self._route_actual = {(j, k): 0 for j in range(NL) for k in range(ND)}
+
+        self._solved = True
+        self._last_solve_time = mine.env.now
+
+    def _maybe_reoptimize(self, mine):
+        now = mine.env.now
+        if not self._solved or (now - self._last_solve_time >= self.reoptimize_interval):
+            self._solve_lp(mine)
+
+    # ──────────────────────────────────────────────────────
+    # Regret-based dynamic bias
+    # ──────────────────────────────────────────────────────
+
+    def _regret_bias(self, ls_idx, ds_idx):
+        """
+        Compute dynamic bias for a route based on regret (deviation from target).
+        Under-served routes get a bonus (lower score multiplier).
+        Over-served routes get a penalty (higher score multiplier).
+        """
+        if self._total_dispatches < 5:
+            # Not enough data, use fixed bias for LP-assigned routes
+            return 0.0
+
+        route = (ls_idx, ds_idx)
+        target_frac = self._route_target.get(route, 0.0)
+        actual_frac = self._route_actual.get(route, 0) / max(self._total_dispatches, 1)
+        deviation = actual_frac - target_frac  # positive = over-served
+
+        # Clamp to [-0.3, 0.3] range for stability
+        return max(-0.3, min(0.3, deviation * 3.0))
+
+    def _shadow_penalty(self, ls_idx=None, ds_idx=None):
+        """
+        Shadow price penalty: sites with high shadow prices are at capacity.
+        Returns a multiplier > 1.0 for congested sites.
+        """
+        penalty = 0.0
+        max_ls = max(self._ls_shadow.values()) if self._ls_shadow else 1.0
+        max_ds = max(self._ds_shadow.values()) if self._ds_shadow else 1.0
+
+        if ls_idx is not None and max_ls > 0:
+            # Normalize shadow price to [0, 1]
+            normalized = self._ls_shadow.get(ls_idx, 0.0) / max_ls
+            penalty += normalized * 0.15  # up to 15% penalty for fully binding
+
+        if ds_idx is not None and max_ds > 0:
+            normalized = self._ds_shadow.get(ds_idx, 0.0) / max_ds
+            penalty += normalized * 0.15
+
+        return penalty
+
+    def _record_dispatch(self, ls_idx, ds_idx):
+        """Record a dispatch for regret tracking."""
+        route = (ls_idx, ds_idx)
+        self._route_actual[route] = self._route_actual.get(route, 0) + 1
+        self._total_dispatches += 1
+
+    # ──────────────────────────────────────────────────────
+    # Dynamic estimation
+    # ──────────────────────────────────────────────────────
+
+    def _load_score(self, truck, mine, ls_idx, dist):
+        ls = mine.load_sites[ls_idx]
+        travel = 60.0 * dist / truck.truck_speed
+        active = [s for s in ls.shovel_list if not s.repair]
+        if not active:
+            return float('inf')
+        prod = sum(s.shovel_tons / s.shovel_cycle_time for s in active)
+        service = truck.truck_capacity / (prod / len(active))
+        queue_wait = ls.estimated_queue_wait_time
+        incoming_cap = sum(
+            t.truck_capacity for t in mine.trucks
+            if t.name != truck.name and t.status == "moving"
+            and t.target_location is not None
+            and isinstance(t.target_location, LoadSite)
+            and t.target_location.name == ls.name
+        )
+        incoming_wait = incoming_cap / prod
+        wait_on_arrival = max(0, queue_wait + incoming_wait - travel)
+        return travel + wait_on_arrival + service
+
+    def _dump_score(self, truck, mine, ls_idx, ds_idx):
+        ds = mine.dump_sites[ds_idx]
+        dist = mine.road.l2d_road_matrix[ls_idx, ds_idx]
+        travel = 60.0 * dist / truck.truck_speed
+        n_dumpers = len(ds.dumper_list)
+        dump_time = ds.dumper_list[0].dump_time if ds.dumper_list else 1.0
+        queue_wait = ds.estimated_queue_wait_time
+        incoming = sum(
+            1 for t in mine.trucks
+            if t.name != truck.name and t.status == "moving"
+            and t.target_location is not None
+            and isinstance(t.target_location, DumpSite)
+            and t.target_location.name == ds.name
+        )
+        incoming_wait = (incoming / max(n_dumpers, 1)) * dump_time
+        wait_on_arrival = max(0, queue_wait + incoming_wait - travel)
+        return travel + wait_on_arrival + dump_time
+
+    def _best_return_time(self, truck, mine, ds_idx):
+        best = float('inf')
+        for j in range(len(mine.load_sites)):
+            dist = mine.road.d2l_road_matrix[j, ds_idx]
+            s = self._load_score(truck, mine, j, dist)
+            if s < best:
+                best = s
+        return best
+
+    # ──────────────────────────────────────────────────────
+    # Dispatch decisions
+    # ──────────────────────────────────────────────────────
+
+    def give_init_order(self, truck: "Truck", mine: "Mine") -> int:
+        self._maybe_reoptimize(mine)
+        assigned_ls, assigned_ds = self._truck_route.get(truck.name, (0, 0))
+
+        best_idx = 0
+        best_score = float('inf')
+
+        for j in range(len(mine.load_sites)):
+            s = self._load_score(truck, mine, j, mine.road.charging_to_load[j])
+
+            # Shadow price: penalize sites at capacity
+            s *= (1.0 + self._shadow_penalty(ls_idx=j))
+
+            # LP assignment bonus (for init, use fixed bias since no regret data yet)
+            if j == assigned_ls:
+                s *= 0.70  # strong bias at start
+
+            if s < best_score:
+                best_score = s
+                best_idx = j
+
+        return best_idx
+
+    def give_haul_order(self, truck: "Truck", mine: "Mine") -> int:
+        self._maybe_reoptimize(mine)
+        ls_idx = mine.load_sites.index(truck.current_location)
+        assigned = self._truck_route.get(truck.name, (0, 0))
+        assigned_ds = assigned[1] if assigned[0] == ls_idx else -1
+
+        best_idx = 0
+        best_score = float('inf')
+
+        for k in range(len(mine.dump_sites)):
+            d = self._dump_score(truck, mine, ls_idx, k)
+            r = self._best_return_time(truck, mine, k)
+            score = d + 0.5 * r
+
+            # Shadow price penalty for dump site
+            score *= (1.0 + self._shadow_penalty(ds_idx=k))
+
+            # Regret-based dynamic bias (replaces fixed lp_bias)
+            regret = self._regret_bias(ls_idx, k)
+            if k == assigned_ds:
+                # LP-preferred: base discount + reduce if over-served
+                score *= (0.70 + regret)
+            else:
+                # Non-LP: base + increase if under-served (regret negative)
+                score *= (1.0 + regret)
+
+            if score < best_score:
+                best_score = score
+                best_idx = k
+
+        self._record_dispatch(ls_idx, best_idx)
+        return best_idx
+
+    def give_back_order(self, truck: "Truck", mine: "Mine") -> int:
+        self._maybe_reoptimize(mine)
+        ds_idx = mine.dump_sites.index(truck.current_location)
+        assigned_ls = self._truck_route.get(truck.name, (0, 0))[0]
+
+        best_idx = 0
+        best_score = float('inf')
+
+        for j in range(len(mine.load_sites)):
+            dist = mine.road.d2l_road_matrix[j, ds_idx]
+            s = self._load_score(truck, mine, j, dist)
+
+            # Shadow price
+            s *= (1.0 + self._shadow_penalty(ls_idx=j))
+
+            # Regret-based bias
+            # For back order, we don't know ds yet, use average regret across dump sites
+            avg_regret = np.mean([self._regret_bias(j, k) for k in range(self._num_ds)]) if self._num_ds > 0 else 0.0
+            if j == assigned_ls:
+                s *= (0.70 + avg_regret)
+            else:
+                s *= (1.0 + avg_regret)
+
+            if s < best_score:
+                best_score = s
+                best_idx = j
+
+        return best_idx

--- a/openmines/src/dispatch_algorithms/lp_dispatcher.py
+++ b/openmines/src/dispatch_algorithms/lp_dispatcher.py
@@ -18,11 +18,12 @@ from openmines.src.dump_site import DumpSite
 
 
 class LPDispatcher(BaseDispatcher):
-    def __init__(self, reoptimize_interval=15, lp_bias=0.30):
+    def __init__(self, reoptimize_interval=15, lp_bias=0.30, utilization_cap=0.70):
         super().__init__()
         self.name = "LPDispatcher"
         self.reoptimize_interval = reoptimize_interval
         self.lp_bias = lp_bias  # discount factor for LP-preferred choices
+        self.utilization_cap = utilization_cap  # max utilization before queue blowup
 
         # LP state
         self._solved = False
@@ -101,9 +102,9 @@ class LPDispatcher(BaseDispatcher):
                 for k in range(ND):
                     row[i * NR + j * ND + k] = throughput[i * NR + j * ND + k]
             A_ub_list.append(row)
-            b_ub_list.append(prod)
+            b_ub_list.append(prod * self.utilization_cap)  # leave headroom for queue stability
 
-        # Inequality: dump site capacity
+        # Inequality: dump site capacity (with utilization cap)
         for k in range(ND):
             ds = mine.dump_sites[k]
             n_dumpers = len(ds.dumper_list)
@@ -115,7 +116,7 @@ class LPDispatcher(BaseDispatcher):
                 for j in range(NL):
                     row[i * NR + j * ND + k] = trip_rate[i * NR + j * ND + k]
             A_ub_list.append(row)
-            b_ub_list.append(cap_trucks_per_min)
+            b_ub_list.append(cap_trucks_per_min * self.utilization_cap)
 
         A_ub = np.array(A_ub_list)
         b_ub = np.array(b_ub_list)
@@ -154,14 +155,38 @@ class LPDispatcher(BaseDispatcher):
             self._solve_lp(mine)
 
     # ──────────────────────────────────────────────────────
-    # Dynamic estimation (SmartDispatcher-style)
+    # Arrival-time-aware dynamic estimation
     # ──────────────────────────────────────────────────────
 
+    def _trucks_arriving_before(self, mine, target, target_type, my_arrival_time):
+        """Count incoming trucks arriving BEFORE our estimated arrival."""
+        count = 0
+        total_cap = 0.0
+        now = mine.env.now
+        for t in mine.trucks:
+            if (t.status == "moving" and t.target_location is not None
+                    and isinstance(t.target_location, target_type)
+                    and t.target_location.name == target.name):
+                their_eta = now
+                try:
+                    for etype in ["haul", "unhaul", "init"]:
+                        evt = t.event_pool.get_last_event(type=etype, strict=False)
+                        if evt and evt.info.get("est_end_time"):
+                            their_eta = evt.info["est_end_time"]
+                            break
+                except (KeyError, IndexError, AssertionError):
+                    their_eta = now
+                if their_eta <= my_arrival_time:
+                    count += 1
+                    total_cap += t.truck_capacity
+        return count, total_cap
+
     def _load_score(self, truck, mine, ls_idx, dist):
-        """Estimate time from departure to finish loading at ls_idx."""
+        """Estimate time from departure to finish loading, with arrival-time-aware queue."""
         ls = mine.load_sites[ls_idx]
         speed = truck.truck_speed
         travel = 60.0 * dist / speed
+        my_arrival = mine.env.now + travel
 
         active = [s for s in ls.shovel_list if not s.repair]
         if not active:
@@ -169,40 +194,27 @@ class LPDispatcher(BaseDispatcher):
         prod = sum(s.shovel_tons / s.shovel_cycle_time for s in active)
         service = truck.truck_capacity / (prod / len(active))
 
-        queue_wait = ls.estimated_queue_wait_time
-        incoming_cap = sum(
-            t.truck_capacity for t in mine.trucks
-            if t.name != truck.name and t.status == "moving"
-            and t.target_location is not None
-            and isinstance(t.target_location, LoadSite)
-            and t.target_location.name == ls.name
-        )
+        queue_at_arrival = max(0, ls.estimated_queue_wait_time - travel)
+        _, incoming_cap = self._trucks_arriving_before(mine, ls, LoadSite, my_arrival)
         incoming_wait = incoming_cap / prod
-        wait_on_arrival = max(0, queue_wait + incoming_wait - travel)
 
-        return travel + wait_on_arrival + service
+        return travel + queue_at_arrival + incoming_wait + service
 
     def _dump_score(self, truck, mine, ls_idx, ds_idx):
-        """Estimate time from load site ls_idx to finish dumping at ds_idx."""
+        """Estimate time from load site to finish dumping, with arrival-time-aware queue."""
         ds = mine.dump_sites[ds_idx]
         dist = mine.road.l2d_road_matrix[ls_idx, ds_idx]
         travel = 60.0 * dist / truck.truck_speed
+        my_arrival = mine.env.now + travel
 
         n_dumpers = len(ds.dumper_list)
         dump_time = ds.dumper_list[0].dump_time if ds.dumper_list else 1.0
 
-        queue_wait = ds.estimated_queue_wait_time
-        incoming = sum(
-            1 for t in mine.trucks
-            if t.name != truck.name and t.status == "moving"
-            and t.target_location is not None
-            and isinstance(t.target_location, DumpSite)
-            and t.target_location.name == ds.name
-        )
-        incoming_wait = (incoming / max(n_dumpers, 1)) * dump_time
-        wait_on_arrival = max(0, queue_wait + incoming_wait - travel)
+        queue_at_arrival = max(0, ds.estimated_queue_wait_time - travel)
+        count_before, _ = self._trucks_arriving_before(mine, ds, DumpSite, my_arrival)
+        incoming_wait = (count_before / max(n_dumpers, 1)) * dump_time
 
-        return travel + wait_on_arrival + dump_time
+        return travel + queue_at_arrival + incoming_wait + dump_time
 
     def _best_return_time(self, truck, mine, ds_idx):
         """Best load site reachable from dump site ds_idx."""
@@ -215,23 +227,17 @@ class LPDispatcher(BaseDispatcher):
         return best
 
     # ──────────────────────────────────────────────────────
-    # Dispatch decisions
+    # Dispatch decisions (LP-biased dynamic with coordination)
     # ──────────────────────────────────────────────────────
 
     def give_init_order(self, truck: "Truck", mine: "Mine") -> int:
-        """
-        For init: use LP assignment but stagger via dynamic scoring.
-        Early trucks follow LP; as queues build, redirect dynamically.
-        """
         self._maybe_reoptimize(mine)
         assigned_ls = self._truck_route.get(truck.name, (0, 0))[0]
 
-        # Score all load sites dynamically
         scores = []
         for j in range(len(mine.load_sites)):
             dist = mine.road.charging_to_load[j]
             s = self._load_score(truck, mine, j, dist)
-            # LP bias: discount the assigned load site
             if j == assigned_ls:
                 s *= (1.0 - self.lp_bias)
             scores.append(s)
@@ -239,10 +245,6 @@ class LPDispatcher(BaseDispatcher):
         return int(np.argmin(scores))
 
     def give_haul_order(self, truck: "Truck", mine: "Mine") -> int:
-        """
-        Dynamic dump selection with return-trip lookahead.
-        LP bias applied to the assigned dump site.
-        """
         self._maybe_reoptimize(mine)
         ls_idx = mine.load_sites.index(truck.current_location)
         assigned = self._truck_route.get(truck.name, (0, 0))
@@ -250,31 +252,24 @@ class LPDispatcher(BaseDispatcher):
 
         best_idx = 0
         best_score = float('inf')
-
         for k in range(len(mine.dump_sites)):
             d = self._dump_score(truck, mine, ls_idx, k)
             r = self._best_return_time(truck, mine, k)
             score = d + 0.5 * r
-            # LP bias
             if k == assigned_ds:
                 score *= (1.0 - self.lp_bias)
             if score < best_score:
                 best_score = score
                 best_idx = k
-
         return best_idx
 
     def give_back_order(self, truck: "Truck", mine: "Mine") -> int:
-        """
-        Dynamic load site selection with LP bias on assigned site.
-        """
         self._maybe_reoptimize(mine)
         ds_idx = mine.dump_sites.index(truck.current_location)
         assigned_ls = self._truck_route.get(truck.name, (0, 0))[0]
 
         best_idx = 0
         best_score = float('inf')
-
         for j in range(len(mine.load_sites)):
             dist = mine.road.d2l_road_matrix[j, ds_idx]
             s = self._load_score(truck, mine, j, dist)
@@ -283,5 +278,4 @@ class LPDispatcher(BaseDispatcher):
             if s < best_score:
                 best_score = s
                 best_idx = j
-
         return best_idx

--- a/openmines/src/dispatch_algorithms/lp_dispatcher.py
+++ b/openmines/src/dispatch_algorithms/lp_dispatcher.py
@@ -1,0 +1,287 @@
+"""
+LPDispatcher: LP-optimal allocation + dynamic queue-aware online dispatch.
+
+Two phases:
+1. OFFLINE: Solve LP to find optimal truck→route allocation maximizing throughput
+2. ONLINE: Use SmartDispatcher-style dynamic estimation for real-time decisions,
+   biased by LP-optimal targets to reduce oscillation
+
+Re-solves LP periodically to adapt to breakdowns and road events.
+"""
+from __future__ import annotations
+import numpy as np
+from scipy.optimize import linprog
+
+from openmines.src.dispatcher import BaseDispatcher
+from openmines.src.load_site import LoadSite
+from openmines.src.dump_site import DumpSite
+
+
+class LPDispatcher(BaseDispatcher):
+    def __init__(self, reoptimize_interval=15, lp_bias=0.30):
+        super().__init__()
+        self.name = "LPDispatcher"
+        self.reoptimize_interval = reoptimize_interval
+        self.lp_bias = lp_bias  # discount factor for LP-preferred choices
+
+        # LP state
+        self._solved = False
+        self._last_solve_time = -999
+        self._truck_route = {}   # truck_name → (ls_idx, ds_idx)
+        self._ls_target = {}     # ls_idx → target fraction of trucks
+        self._num_ls = 0
+        self._num_ds = 0
+
+    # ──────────────────────────────────────────────────────
+    # LP Solver
+    # ──────────────────────────────────────────────────────
+
+    def _cycle_time(self, cap, speed, ls, ls_idx, ds, ds_idx, mine):
+        """Full round-trip cycle time in minutes."""
+        l2d = mine.road.l2d_road_matrix[ls_idx, ds_idx]
+        d2l = mine.road.d2l_road_matrix[ls_idx, ds_idx]
+        travel = 60.0 * (l2d + d2l) / speed
+
+        active = [s for s in ls.shovel_list if not s.repair]
+        if not active:
+            return float('inf')
+        prod = sum(s.shovel_tons / s.shovel_cycle_time for s in active)
+        load_time = cap / (prod / len(active))
+
+        unload = ds.dumper_list[0].dump_time if ds.dumper_list else 1.0
+        return travel + load_time + unload
+
+    def _solve_lp(self, mine):
+        trucks = mine.trucks
+        NL = len(mine.load_sites)
+        ND = len(mine.dump_sites)
+        NT = len(trucks)
+        NR = NL * ND
+        NV = NT * NR
+        self._num_ls = NL
+        self._num_ds = ND
+
+        # Precompute throughput[i,r] and trip_rate[i,r]
+        throughput = np.zeros(NV)
+        trip_rate = np.zeros(NV)
+
+        for i, truck in enumerate(trucks):
+            for j in range(NL):
+                for k in range(ND):
+                    r = j * ND + k
+                    idx = i * NR + r
+                    ct = self._cycle_time(
+                        truck.truck_capacity, truck.truck_speed,
+                        mine.load_sites[j], j, mine.dump_sites[k], k, mine
+                    )
+                    if ct > 0 and ct != float('inf'):
+                        throughput[idx] = truck.truck_capacity / ct
+                        trip_rate[idx] = 1.0 / ct
+
+        # Objective: minimize -throughput
+        c = -throughput
+
+        # Equality: each truck allocated to exactly 1 unit of routes
+        A_eq = np.zeros((NT, NV))
+        for i in range(NT):
+            A_eq[i, i * NR:(i + 1) * NR] = 1.0
+        b_eq = np.ones(NT)
+
+        # Inequality: load site capacity
+        A_ub_list = []
+        b_ub_list = []
+
+        for j in range(NL):
+            ls = mine.load_sites[j]
+            active = [s for s in ls.shovel_list if not s.repair]
+            prod = sum(s.shovel_tons / s.shovel_cycle_time for s in active) if active else 0.01
+
+            row = np.zeros(NV)
+            for i in range(NT):
+                for k in range(ND):
+                    row[i * NR + j * ND + k] = throughput[i * NR + j * ND + k]
+            A_ub_list.append(row)
+            b_ub_list.append(prod)
+
+        # Inequality: dump site capacity
+        for k in range(ND):
+            ds = mine.dump_sites[k]
+            n_dumpers = len(ds.dumper_list)
+            unload = ds.dumper_list[0].dump_time if ds.dumper_list else 1.0
+            cap_trucks_per_min = n_dumpers / unload
+
+            row = np.zeros(NV)
+            for i in range(NT):
+                for j in range(NL):
+                    row[i * NR + j * ND + k] = trip_rate[i * NR + j * ND + k]
+            A_ub_list.append(row)
+            b_ub_list.append(cap_trucks_per_min)
+
+        A_ub = np.array(A_ub_list)
+        b_ub = np.array(b_ub_list)
+        bounds = [(0, 1)] * NV
+
+        result = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
+                         bounds=bounds, method='highs')
+
+        if result.success:
+            x = result.x
+        else:
+            x = np.ones(NV) / NR
+
+        # Extract per-truck primary assignment
+        self._truck_route = {}
+        ls_truck_count = np.zeros(NL)
+
+        for i, truck in enumerate(trucks):
+            allocs = x[i * NR:(i + 1) * NR]
+            best_r = np.argmax(allocs)
+            j = best_r // ND
+            k = best_r % ND
+            self._truck_route[truck.name] = (j, k)
+            ls_truck_count[j] += 1
+
+        # Target load site fractions (for bias)
+        total = ls_truck_count.sum()
+        self._ls_target = {j: ls_truck_count[j] / total for j in range(NL)} if total > 0 else {}
+
+        self._solved = True
+        self._last_solve_time = mine.env.now
+
+    def _maybe_reoptimize(self, mine):
+        now = mine.env.now
+        if not self._solved or (now - self._last_solve_time >= self.reoptimize_interval):
+            self._solve_lp(mine)
+
+    # ──────────────────────────────────────────────────────
+    # Dynamic estimation (SmartDispatcher-style)
+    # ──────────────────────────────────────────────────────
+
+    def _load_score(self, truck, mine, ls_idx, dist):
+        """Estimate time from departure to finish loading at ls_idx."""
+        ls = mine.load_sites[ls_idx]
+        speed = truck.truck_speed
+        travel = 60.0 * dist / speed
+
+        active = [s for s in ls.shovel_list if not s.repair]
+        if not active:
+            return float('inf')
+        prod = sum(s.shovel_tons / s.shovel_cycle_time for s in active)
+        service = truck.truck_capacity / (prod / len(active))
+
+        queue_wait = ls.estimated_queue_wait_time
+        incoming_cap = sum(
+            t.truck_capacity for t in mine.trucks
+            if t.name != truck.name and t.status == "moving"
+            and t.target_location is not None
+            and isinstance(t.target_location, LoadSite)
+            and t.target_location.name == ls.name
+        )
+        incoming_wait = incoming_cap / prod
+        wait_on_arrival = max(0, queue_wait + incoming_wait - travel)
+
+        return travel + wait_on_arrival + service
+
+    def _dump_score(self, truck, mine, ls_idx, ds_idx):
+        """Estimate time from load site ls_idx to finish dumping at ds_idx."""
+        ds = mine.dump_sites[ds_idx]
+        dist = mine.road.l2d_road_matrix[ls_idx, ds_idx]
+        travel = 60.0 * dist / truck.truck_speed
+
+        n_dumpers = len(ds.dumper_list)
+        dump_time = ds.dumper_list[0].dump_time if ds.dumper_list else 1.0
+
+        queue_wait = ds.estimated_queue_wait_time
+        incoming = sum(
+            1 for t in mine.trucks
+            if t.name != truck.name and t.status == "moving"
+            and t.target_location is not None
+            and isinstance(t.target_location, DumpSite)
+            and t.target_location.name == ds.name
+        )
+        incoming_wait = (incoming / max(n_dumpers, 1)) * dump_time
+        wait_on_arrival = max(0, queue_wait + incoming_wait - travel)
+
+        return travel + wait_on_arrival + dump_time
+
+    def _best_return_time(self, truck, mine, ds_idx):
+        """Best load site reachable from dump site ds_idx."""
+        best = float('inf')
+        for j in range(len(mine.load_sites)):
+            dist = mine.road.d2l_road_matrix[j, ds_idx]
+            score = self._load_score(truck, mine, j, dist)
+            if score < best:
+                best = score
+        return best
+
+    # ──────────────────────────────────────────────────────
+    # Dispatch decisions
+    # ──────────────────────────────────────────────────────
+
+    def give_init_order(self, truck: "Truck", mine: "Mine") -> int:
+        """
+        For init: use LP assignment but stagger via dynamic scoring.
+        Early trucks follow LP; as queues build, redirect dynamically.
+        """
+        self._maybe_reoptimize(mine)
+        assigned_ls = self._truck_route.get(truck.name, (0, 0))[0]
+
+        # Score all load sites dynamically
+        scores = []
+        for j in range(len(mine.load_sites)):
+            dist = mine.road.charging_to_load[j]
+            s = self._load_score(truck, mine, j, dist)
+            # LP bias: discount the assigned load site
+            if j == assigned_ls:
+                s *= (1.0 - self.lp_bias)
+            scores.append(s)
+
+        return int(np.argmin(scores))
+
+    def give_haul_order(self, truck: "Truck", mine: "Mine") -> int:
+        """
+        Dynamic dump selection with return-trip lookahead.
+        LP bias applied to the assigned dump site.
+        """
+        self._maybe_reoptimize(mine)
+        ls_idx = mine.load_sites.index(truck.current_location)
+        assigned = self._truck_route.get(truck.name, (0, 0))
+        assigned_ds = assigned[1] if assigned[0] == ls_idx else -1
+
+        best_idx = 0
+        best_score = float('inf')
+
+        for k in range(len(mine.dump_sites)):
+            d = self._dump_score(truck, mine, ls_idx, k)
+            r = self._best_return_time(truck, mine, k)
+            score = d + 0.5 * r
+            # LP bias
+            if k == assigned_ds:
+                score *= (1.0 - self.lp_bias)
+            if score < best_score:
+                best_score = score
+                best_idx = k
+
+        return best_idx
+
+    def give_back_order(self, truck: "Truck", mine: "Mine") -> int:
+        """
+        Dynamic load site selection with LP bias on assigned site.
+        """
+        self._maybe_reoptimize(mine)
+        ds_idx = mine.dump_sites.index(truck.current_location)
+        assigned_ls = self._truck_route.get(truck.name, (0, 0))[0]
+
+        best_idx = 0
+        best_score = float('inf')
+
+        for j in range(len(mine.load_sites)):
+            dist = mine.road.d2l_road_matrix[j, ds_idx]
+            s = self._load_score(truck, mine, j, dist)
+            if j == assigned_ls:
+                s *= (1.0 - self.lp_bias)
+            if s < best_score:
+                best_score = s
+                best_idx = j
+
+        return best_idx

--- a/openmines/src/dispatch_algorithms/mpc_dispatcher.py
+++ b/openmines/src/dispatch_algorithms/mpc_dispatcher.py
@@ -1,0 +1,345 @@
+"""
+MPCDispatcher: Model Predictive Control based dispatch.
+
+Instead of solving a steady-state LP, MPC solves a short-horizon assignment
+problem at each decision point considering the CURRENT system snapshot:
+- Trucks on roads with estimated arrival times
+- Current queue lengths and wait times
+- Active road events (jams, repairs)
+- Shovel/dumper maintenance status
+
+Uses scipy.optimize.linear_sum_assignment for the assignment subproblem.
+
+Key difference from LPDispatcher: MPC models the transient dynamics
+(trucks in transit, queue buildup) rather than assuming steady state.
+"""
+from __future__ import annotations
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+
+from openmines.src.dispatcher import BaseDispatcher
+from openmines.src.load_site import LoadSite
+from openmines.src.dump_site import DumpSite
+
+
+class MPCDispatcher(BaseDispatcher):
+    def __init__(self, horizon=30):
+        super().__init__()
+        self.name = "MPCDispatcher"
+        self.horizon = horizon  # lookahead in minutes
+
+        # Cached plan: solved once per simulation timestep, shared across truck calls
+        self._plan_time = -1
+        self._plan = {}          # truck_name → (ls_idx, ds_idx)
+        self._ls_assignments = None  # per load site: count of trucks assigned this step
+        self._ds_assignments = None
+
+    def _take_snapshot(self, mine):
+        """
+        Build a snapshot of the current system state.
+        Returns structured info about trucks, queues, and capacities.
+        """
+        now = mine.env.now
+        NL = len(mine.load_sites)
+        ND = len(mine.dump_sites)
+
+        # Load site info
+        ls_info = []
+        for j, ls in enumerate(mine.load_sites):
+            active = [s for s in ls.shovel_list if not s.repair]
+            prod = sum(s.shovel_tons / s.shovel_cycle_time for s in active) if active else 0.01
+            n_active = len(active) if active else 0
+            ls_info.append({
+                'prod': prod,
+                'n_shovels': n_active,
+                'queue_wait': ls.estimated_queue_wait_time,
+            })
+
+        # Dump site info
+        ds_info = []
+        for k, ds in enumerate(mine.dump_sites):
+            n_dumpers = len(ds.dumper_list)
+            dump_time = ds.dumper_list[0].dump_time if ds.dumper_list else 1.0
+            ds_info.append({
+                'n_dumpers': n_dumpers,
+                'dump_time': dump_time,
+                'queue_wait': ds.estimated_queue_wait_time,
+            })
+
+        # Count trucks heading to each site (capacity already committed)
+        ls_incoming_cap = np.zeros(NL)
+        ds_incoming_count = np.zeros(ND)
+        for t in mine.trucks:
+            if t.status == "moving" and t.target_location is not None:
+                if isinstance(t.target_location, LoadSite):
+                    for j, ls in enumerate(mine.load_sites):
+                        if t.target_location.name == ls.name:
+                            ls_incoming_cap[j] += t.truck_capacity
+                            break
+                elif isinstance(t.target_location, DumpSite):
+                    for k, ds in enumerate(mine.dump_sites):
+                        if t.target_location.name == ds.name:
+                            ds_incoming_count[k] += 1
+                            break
+
+        return {
+            'now': now, 'NL': NL, 'ND': ND,
+            'ls_info': ls_info, 'ds_info': ds_info,
+            'ls_incoming_cap': ls_incoming_cap,
+            'ds_incoming_count': ds_incoming_count,
+        }
+
+    def _estimate_throughput(self, truck, mine, snap, ls_idx, ds_idx):
+        """
+        Estimate production rate (tons/min) for a truck on route (ls_idx → ds_idx),
+        considering current system state.
+        """
+        ls = snap['ls_info'][ls_idx]
+        ds = snap['ds_info'][ds_idx]
+        speed = truck.truck_speed
+        cap = truck.truck_capacity
+
+        if ls['n_shovels'] == 0:
+            return 0.0
+
+        # Travel time
+        l2d = mine.road.l2d_road_matrix[ls_idx, ds_idx]
+        d2l = mine.road.d2l_road_matrix[ls_idx, ds_idx]
+        travel = 60.0 * (l2d + d2l) / speed
+
+        # Load time at individual shovel
+        load_time = cap / (ls['prod'] / ls['n_shovels'])
+
+        # Queue wait at load site (considering incoming)
+        ls_queue = ls['queue_wait'] + snap['ls_incoming_cap'][ls_idx] / ls['prod']
+
+        # Dump time
+        dump_time = ds['dump_time']
+
+        # Queue wait at dump site (considering incoming)
+        ds_queue = ds['queue_wait'] + (snap['ds_incoming_count'][ds_idx] / max(ds['n_dumpers'], 1)) * dump_time
+
+        cycle = travel + load_time + dump_time + ls_queue + ds_queue
+        if cycle <= 0:
+            return 0.0
+
+        return cap / cycle
+
+    def _estimate_total_time(self, truck, mine, snap, ls_idx, ds_idx, from_location, is_init=False):
+        """
+        Estimate total time for a full cycle starting from current position.
+        Used for the assignment cost matrix.
+        """
+        speed = truck.truck_speed
+        cap = truck.truck_capacity
+        ls = snap['ls_info'][ls_idx]
+        ds = snap['ds_info'][ds_idx]
+
+        if ls['n_shovels'] == 0:
+            return float('inf')
+
+        # Phase 1: Travel to load site
+        if is_init:
+            dist_to_ls = mine.road.charging_to_load[ls_idx]
+        elif isinstance(from_location, DumpSite):
+            from_ds_idx = mine.dump_sites.index(from_location)
+            dist_to_ls = mine.road.d2l_road_matrix[ls_idx, from_ds_idx]
+        else:
+            dist_to_ls = 0
+
+        travel_to_ls = 60.0 * dist_to_ls / speed
+
+        # Queue at load site (penalized by how many we've already assigned this step)
+        extra_ls = 0
+        if self._ls_assignments is not None:
+            extra_ls = (self._ls_assignments[ls_idx] * cap) / ls['prod']
+        ls_queue = ls['queue_wait'] + snap['ls_incoming_cap'][ls_idx] / ls['prod'] + extra_ls
+        wait_at_ls = max(0, ls_queue - travel_to_ls)
+
+        # Loading
+        load_time = cap / (ls['prod'] / ls['n_shovels'])
+
+        # Phase 2: Travel to dump site
+        l2d = mine.road.l2d_road_matrix[ls_idx, ds_idx]
+        travel_to_ds = 60.0 * l2d / speed
+
+        # Queue at dump site
+        extra_ds = 0
+        if self._ds_assignments is not None:
+            extra_ds = (self._ds_assignments[ds_idx] / max(ds['n_dumpers'], 1)) * ds['dump_time']
+        ds_queue = ds['queue_wait'] + (snap['ds_incoming_count'][ds_idx] / max(ds['n_dumpers'], 1)) * ds['dump_time'] + extra_ds
+        wait_at_ds = max(0, ds_queue - travel_to_ds)
+
+        # Dumping
+        dump_time = ds['dump_time']
+
+        total = travel_to_ls + wait_at_ls + load_time + travel_to_ds + wait_at_ds + dump_time
+
+        # Throughput: prefer routes with high tons/time
+        # Negative throughput = cost (we want to minimize cost = maximize throughput)
+        return total / max(cap, 1)  # normalize by capacity: time per ton
+
+    def _solve_assignment(self, truck, mine, snap, destinations, from_location, is_init=False):
+        """
+        For the current truck, evaluate all (ls, ds) route pairs and pick the best.
+        Considers trucks already assigned in this planning step.
+        """
+        NL = snap['NL']
+        ND = snap['ND']
+
+        best_score = float('inf')
+        best_ls = 0
+        best_ds = 0
+
+        for j in range(NL):
+            for k in range(ND):
+                score = self._estimate_total_time(
+                    truck, mine, snap, j, k, from_location, is_init
+                )
+                # Also consider return trip quality
+                d2l_dists = mine.road.d2l_road_matrix[:, k]
+                best_return = min(
+                    self._estimate_total_time(truck, mine, snap, jj, k, mine.dump_sites[k])
+                    for jj in range(NL)
+                    if snap['ls_info'][jj]['n_shovels'] > 0
+                ) if any(snap['ls_info'][jj]['n_shovels'] > 0 for jj in range(NL)) else 0
+
+                total = score + 0.3 * best_return
+
+                if total < best_score:
+                    best_score = total
+                    best_ls = j
+                    best_ds = k
+
+        # Record assignment for future trucks in same planning step
+        if self._ls_assignments is not None:
+            self._ls_assignments[best_ls] += 1
+        if self._ds_assignments is not None:
+            self._ds_assignments[best_ds] += 1
+
+        return best_ls, best_ds
+
+    def _ensure_plan(self, mine):
+        """Reset assignment counters at each new simulation timestep."""
+        now = int(mine.env.now * 10)  # discretize to 0.1 min
+        if now != self._plan_time:
+            self._plan_time = now
+            self._ls_assignments = np.zeros(len(mine.load_sites))
+            self._ds_assignments = np.zeros(len(mine.dump_sites))
+
+    # ──────────────────────────────────────────────────────
+    # Dispatch decisions
+    # ──────────────────────────────────────────────────────
+
+    def give_init_order(self, truck: "Truck", mine: "Mine") -> int:
+        self._ensure_plan(mine)
+        snap = self._take_snapshot(mine)
+        ls, ds = self._solve_assignment(truck, mine, snap, None, None, is_init=True)
+        self._plan[truck.name] = (ls, ds)
+        return ls
+
+    def give_haul_order(self, truck: "Truck", mine: "Mine") -> int:
+        self._ensure_plan(mine)
+        snap = self._take_snapshot(mine)
+        current_location = truck.current_location
+        ls_idx = mine.load_sites.index(current_location)
+
+        # Evaluate dump sites considering current position
+        NL = snap['NL']
+        ND = snap['ND']
+        best_ds = 0
+        best_score = float('inf')
+
+        for k in range(ND):
+            ds = snap['ds_info'][k]
+            dist = mine.road.l2d_road_matrix[ls_idx, k]
+            travel = 60.0 * dist / truck.truck_speed
+
+            dump_time = ds['dump_time']
+            n_dumpers = ds['n_dumpers']
+
+            extra_ds = 0
+            if self._ds_assignments is not None:
+                extra_ds = (self._ds_assignments[k] / max(n_dumpers, 1)) * dump_time
+
+            ds_queue = ds['queue_wait'] + (snap['ds_incoming_count'][k] / max(n_dumpers, 1)) * dump_time + extra_ds
+            wait_at_ds = max(0, ds_queue - travel)
+
+            score = travel + wait_at_ds + dump_time
+
+            # Return trip quality
+            best_return = float('inf')
+            for jj in range(NL):
+                if snap['ls_info'][jj]['n_shovels'] == 0:
+                    continue
+                ret_dist = mine.road.d2l_road_matrix[jj, k]
+                ret_travel = 60.0 * ret_dist / truck.truck_speed
+                ls_q = snap['ls_info'][jj]['queue_wait'] + snap['ls_incoming_cap'][jj] / snap['ls_info'][jj]['prod']
+                ret_wait = max(0, ls_q - ret_travel)
+                ret_service = truck.truck_capacity / (snap['ls_info'][jj]['prod'] / snap['ls_info'][jj]['n_shovels'])
+                ret_total = ret_travel + ret_wait + ret_service
+                if ret_total < best_return:
+                    best_return = ret_total
+
+            total = score + 0.5 * best_return
+
+            if total < best_score:
+                best_score = total
+                best_ds = k
+
+        if self._ds_assignments is not None:
+            self._ds_assignments[best_ds] += 1
+
+        return best_ds
+
+    def give_back_order(self, truck: "Truck", mine: "Mine") -> int:
+        self._ensure_plan(mine)
+        snap = self._take_snapshot(mine)
+        current_location = truck.current_location
+        ds_idx = mine.dump_sites.index(current_location)
+
+        NL = snap['NL']
+        ND = snap['ND']
+        best_ls = 0
+        best_score = float('inf')
+
+        for j in range(NL):
+            ls = snap['ls_info'][j]
+            if ls['n_shovels'] == 0:
+                continue
+
+            dist = mine.road.d2l_road_matrix[j, ds_idx]
+            travel = 60.0 * dist / truck.truck_speed
+
+            extra_ls = 0
+            if self._ls_assignments is not None:
+                extra_ls = (self._ls_assignments[j] * truck.truck_capacity) / ls['prod']
+
+            ls_queue = ls['queue_wait'] + snap['ls_incoming_cap'][j] / ls['prod'] + extra_ls
+            wait_at_ls = max(0, ls_queue - travel)
+            service = truck.truck_capacity / (ls['prod'] / ls['n_shovels'])
+
+            score = travel + wait_at_ls + service
+
+            # Dump site lookahead
+            best_dump = float('inf')
+            for k in range(ND):
+                d_dist = mine.road.l2d_road_matrix[j, k]
+                d_travel = 60.0 * d_dist / truck.truck_speed
+                ds_info = snap['ds_info'][k]
+                d_queue = ds_info['queue_wait'] + (snap['ds_incoming_count'][k] / max(ds_info['n_dumpers'], 1)) * ds_info['dump_time']
+                d_wait = max(0, d_queue - d_travel)
+                d_total = d_travel + d_wait + ds_info['dump_time']
+                if d_total < best_dump:
+                    best_dump = d_total
+
+            total = score + 0.5 * best_dump
+
+            if total < best_score:
+                best_score = total
+                best_ls = j
+
+        if self._ls_assignments is not None:
+            self._ls_assignments[best_ls] += 1
+
+        return best_ls

--- a/openmines/src/dispatch_algorithms/smart_dispatcher.py
+++ b/openmines/src/dispatch_algorithms/smart_dispatcher.py
@@ -1,0 +1,205 @@
+"""
+SmartDispatcher: A full-cycle-aware dynamic dispatch algorithm.
+
+Key ideas beyond existing algorithms:
+1. Full round-trip lookahead: when choosing a load site, also considers the best
+   dump site reachable from there (and vice versa), optimizing total cycle time.
+2. Capacity-weighted queue estimation: weights incoming trucks by their capacity
+   relative to site productivity, not just count.
+3. Road event awareness: penalizes routes going through jammed/repaired roads.
+4. Multi-shovel parallelism: accounts for the number of available shovels/dumpers
+   to estimate true service throughput.
+5. Adaptive load balancing: combines time-optimal greedy with queue-balancing
+   to prevent starvation of high-productivity sites.
+"""
+from __future__ import annotations
+import numpy as np
+
+from openmines.src.dispatcher import BaseDispatcher
+from openmines.src.load_site import LoadSite
+from openmines.src.dump_site import DumpSite
+
+
+class SmartDispatcher(BaseDispatcher):
+    def __init__(self):
+        super().__init__()
+        self.name = "SmartDispatcher"
+
+    def _get_road_jam_penalty(self, mine, start, end) -> float:
+        """Estimate extra travel time (minutes) from active jam events on a road."""
+        penalty = 0.0
+        for event_key, event in mine.random_event_pool.event_set.items():
+            if event.event_type == "RoadEvent:jam":
+                info = event.info
+                if (info.get("start_location") == start.name and
+                        info.get("end_location") == end.name):
+                    penalty += info.get("jam_delay", 0.5)
+            elif event.event_type == "RoadEvent:repair":
+                info = event.info
+                if (info.get("start_location") == start.name and
+                        info.get("end_location") == end.name):
+                    penalty += info.get("punish_distance", 0.0) * 60.0 / 25.0  # extra km → minutes
+        return penalty
+
+    def _count_incoming_capacity(self, mine, target, target_type) -> float:
+        """Sum up truck_capacity of all trucks heading to a target location."""
+        total = 0.0
+        for t in mine.trucks:
+            if t.target_location is not None and t.status == "moving":
+                if isinstance(t.target_location, target_type):
+                    if t.target_location.name == target.name:
+                        total += t.truck_capacity
+        return total
+
+    def _estimate_load_time(self, truck, load_site, mine, from_location, is_charging=False):
+        """
+        Estimate total time from current location to load_site, including:
+        - Travel time
+        - Queue wait (capacity-weighted)
+        - Loading service time
+        """
+        speed = truck.truck_speed  # km/h
+        now = mine.env.now
+
+        # Travel distance
+        if is_charging:
+            ls_idx = mine.load_sites.index(load_site)
+            dist = mine.road.charging_to_load[ls_idx]
+        elif isinstance(from_location, DumpSite):
+            ds_idx = mine.dump_sites.index(from_location)
+            ls_idx = mine.load_sites.index(load_site)
+            dist = mine.road.d2l_road_matrix[ls_idx, ds_idx]
+        else:
+            ls_idx = mine.load_sites.index(load_site)
+            dist = 0
+
+        travel_time = 60.0 * dist / speed  # minutes
+
+        # Road jam penalty
+        if is_charging:
+            jam_penalty = self._get_road_jam_penalty(mine, mine.charging_site, load_site)
+        elif isinstance(from_location, DumpSite):
+            jam_penalty = self._get_road_jam_penalty(mine, from_location, load_site)
+        else:
+            jam_penalty = 0
+
+        travel_time += jam_penalty
+
+        # Queue estimation: existing queue wait + incoming truck capacity / productivity
+        queue_wait = load_site.estimated_queue_wait_time
+        incoming_cap = self._count_incoming_capacity(mine, load_site, LoadSite)
+        productivity = max(load_site.load_site_productivity, 0.01)
+        num_shovels = max(len(load_site.shovel_list), 1)
+        incoming_wait = incoming_cap / productivity
+
+        # Service time for this truck
+        service_time = truck.truck_capacity / (productivity / num_shovels)
+
+        # Effective wait: max(travel_time, queue_wait + incoming_wait) - travel_time gives wait-on-arrival
+        arrival_time = now + travel_time
+        queue_finish_time = now + queue_wait + incoming_wait
+        effective_wait = max(0, queue_finish_time - arrival_time)
+
+        return travel_time + effective_wait + service_time
+
+    def _estimate_dump_time(self, truck, dump_site, mine, from_load_site):
+        """
+        Estimate total time from a load site to dump_site, including:
+        - Travel time
+        - Queue wait
+        - Unloading time
+        """
+        speed = truck.truck_speed
+        now = mine.env.now
+
+        ls_idx = mine.load_sites.index(from_load_site)
+        ds_idx = mine.dump_sites.index(dump_site)
+        dist = mine.road.l2d_road_matrix[ls_idx, ds_idx]
+        travel_time = 60.0 * dist / speed
+
+        # Road jam penalty
+        jam_penalty = self._get_road_jam_penalty(mine, from_load_site, dump_site)
+        travel_time += jam_penalty
+
+        # Queue estimation
+        queue_wait = dump_site.estimated_queue_wait_time
+        incoming_count = sum(
+            1 for t in mine.trucks
+            if t.target_location is not None and t.status == "moving"
+            and isinstance(t.target_location, DumpSite)
+            and t.target_location.name == dump_site.name
+        )
+        num_dumpers = max(len(dump_site.dumper_list), 1)
+        dump_time = dump_site.dumper_list[0].dump_time if dump_site.dumper_list else 1.0
+        incoming_wait = (incoming_count / num_dumpers) * dump_time
+
+        arrival_time = now + travel_time
+        queue_finish_time = now + queue_wait + incoming_wait
+        effective_wait = max(0, queue_finish_time - arrival_time)
+
+        return travel_time + effective_wait + dump_time
+
+    def _best_dump_time_for_load_site(self, truck, load_site, mine):
+        """Find the minimum dump time from a load site across all dump sites."""
+        best = float('inf')
+        for ds in mine.dump_sites:
+            t = self._estimate_dump_time(truck, ds, mine, load_site)
+            if t < best:
+                best = t
+        return best
+
+    def _best_load_time_for_dump_site(self, truck, dump_site, mine):
+        """Find the minimum load time from a dump site across all load sites."""
+        best = float('inf')
+        for ls in mine.load_sites:
+            t = self._estimate_load_time(truck, ls, mine, dump_site)
+            if t < best:
+                best = t
+        return best
+
+    def give_init_order(self, truck: "Truck", mine: "Mine") -> int:
+        """Choose load site minimizing (travel + wait + load + best_dump_time)."""
+        best_idx = 0
+        best_score = float('inf')
+
+        for i, ls in enumerate(mine.load_sites):
+            load_time = self._estimate_load_time(truck, ls, mine, None, is_charging=True)
+            dump_time = self._best_dump_time_for_load_site(truck, ls, mine)
+            score = load_time + dump_time
+            if score < best_score:
+                best_score = score
+                best_idx = i
+
+        return best_idx
+
+    def give_haul_order(self, truck: "Truck", mine: "Mine") -> int:
+        """Choose dump site minimizing (travel + wait + dump + best_return_load_time)."""
+        current_location = truck.current_location
+        best_idx = 0
+        best_score = float('inf')
+
+        for i, ds in enumerate(mine.dump_sites):
+            dump_time = self._estimate_dump_time(truck, ds, mine, current_location)
+            return_time = self._best_load_time_for_dump_site(truck, ds, mine)
+            score = dump_time + return_time
+            if score < best_score:
+                best_score = score
+                best_idx = i
+
+        return best_idx
+
+    def give_back_order(self, truck: "Truck", mine: "Mine") -> int:
+        """Choose load site minimizing (travel + wait + load + best_dump_time)."""
+        current_location = truck.current_location
+        best_idx = 0
+        best_score = float('inf')
+
+        for i, ls in enumerate(mine.load_sites):
+            load_time = self._estimate_load_time(truck, ls, mine, current_location)
+            dump_time = self._best_dump_time_for_load_site(truck, ls, mine)
+            score = load_time + dump_time
+            if score < best_score:
+                best_score = score
+                best_idx = i
+
+        return best_idx

--- a/openmines/src/dispatch_algorithms/smart_dispatcher.py
+++ b/openmines/src/dispatch_algorithms/smart_dispatcher.py
@@ -1,11 +1,12 @@
 """
-SmartDispatcher: Enhanced dynamic dispatch based on ShortestTrip.
+SmartDispatcher v4: Arrival-time-aware + coordinated dispatch.
 
-Improvements over ShortestTripDispatcher:
-1. Dump site selection considers return trip quality (not just dump time)
-2. Separates "trucks on road" from "trucks in queue" to avoid double-counting
-3. Uses individual shovel/dumper availability instead of site-level averages
-4. Accounts for truck capacity differences in queue estimation
+Two key improvements over previous versions:
+1. Only counts trucks arriving BEFORE this truck in queue estimation
+2. Coordinated dispatch: when a truck picks a site, a "virtual load" is added
+   to that site's queue estimate for subsequent trucks within the same time
+   window, preventing multiple trucks from making identical greedy choices
+   (the herd effect).
 """
 from __future__ import annotations
 import numpy as np
@@ -19,153 +20,157 @@ class SmartDispatcher(BaseDispatcher):
     def __init__(self):
         super().__init__()
         self.name = "SmartDispatcher"
+        # Coordination state: tracks recent dispatch decisions
+        self._recent_ls_load = {}  # ls_idx → (time, accumulated_cap)
+        self._recent_ds_load = {}  # ds_idx → (time, accumulated_count)
+        self._coord_window = 1.0   # coordination window in sim minutes
 
-    def _road_trucks_to_load(self, mine, ls_idx):
-        """Trucks currently on road heading to this load site."""
-        ls = mine.load_sites[ls_idx]
-        total_cap = 0.0
-        for t in mine.trucks:
-            if (t.status == "moving" and t.target_location is not None
-                    and isinstance(t.target_location, LoadSite)
-                    and t.target_location.name == ls.name):
-                total_cap += t.truck_capacity
-        return total_cap
+    def _get_coord_load_ls(self, ls_idx, now):
+        """Get accumulated virtual load at a load site from recent dispatches."""
+        entry = self._recent_ls_load.get(ls_idx)
+        if entry and (now - entry[0]) < self._coord_window:
+            return entry[1]
+        return 0.0
 
-    def _road_trucks_to_dump(self, mine, ds_idx):
-        """Count trucks currently on road heading to this dump site."""
-        ds = mine.dump_sites[ds_idx]
+    def _get_coord_load_ds(self, ds_idx, now):
+        """Get accumulated virtual truck count at dump site from recent dispatches."""
+        entry = self._recent_ds_load.get(ds_idx)
+        if entry and (now - entry[0]) < self._coord_window:
+            return entry[1]
+        return 0
+
+    def _record_ls_dispatch(self, ls_idx, truck_cap, now):
+        """Record that a truck was dispatched to this load site."""
+        entry = self._recent_ls_load.get(ls_idx)
+        if entry and (now - entry[0]) < self._coord_window:
+            self._recent_ls_load[ls_idx] = (entry[0], entry[1] + truck_cap)
+        else:
+            self._recent_ls_load[ls_idx] = (now, truck_cap)
+
+    def _record_ds_dispatch(self, ds_idx, now):
+        """Record that a truck was dispatched to this dump site."""
+        entry = self._recent_ds_load.get(ds_idx)
+        if entry and (now - entry[0]) < self._coord_window:
+            self._recent_ds_load[ds_idx] = (entry[0], entry[1] + 1)
+        else:
+            self._recent_ds_load[ds_idx] = (now, 1)
+
+    def _trucks_arriving_before(self, mine, target, target_type, my_arrival_time):
+        """Count incoming trucks whose ETA is before ours."""
         count = 0
+        total_cap = 0.0
+        now = mine.env.now
         for t in mine.trucks:
             if (t.status == "moving" and t.target_location is not None
-                    and isinstance(t.target_location, DumpSite)
-                    and t.target_location.name == ds.name):
-                count += 1
-        return count
-
-    def _available_shovels(self, load_site):
-        """Count shovels not under maintenance."""
-        return sum(1 for s in load_site.shovel_list if not s.repair)
+                    and isinstance(t.target_location, target_type)
+                    and t.target_location.name == target.name):
+                their_eta = now
+                try:
+                    for etype in ["haul", "unhaul", "init"]:
+                        evt = t.event_pool.get_last_event(type=etype, strict=False)
+                        if evt and evt.info.get("est_end_time"):
+                            their_eta = evt.info["est_end_time"]
+                            break
+                except (KeyError, IndexError, AssertionError):
+                    their_eta = now
+                if their_eta <= my_arrival_time:
+                    count += 1
+                    total_cap += t.truck_capacity
+        return count, total_cap
 
     def _load_site_score(self, truck, mine, ls_idx, travel_dist):
-        """
-        Score a load site: lower = better.
-        Returns estimated time from departure to finish loading.
-        """
         ls = mine.load_sites[ls_idx]
         speed = truck.truck_speed
-        travel_time = 60.0 * travel_dist / speed
+        my_travel = 60.0 * travel_dist / speed
+        my_arrival = mine.env.now + my_travel
+        now = mine.env.now
 
-        # Productivity: only count non-broken shovels
-        active_shovels = self._available_shovels(ls)
-        if active_shovels == 0:
-            return float('inf')  # site is down
+        active_shovels = [s for s in ls.shovel_list if not s.repair]
+        if not active_shovels:
+            return float('inf')
+        n_active = len(active_shovels)
+        productivity = sum(s.shovel_tons / s.shovel_cycle_time for s in active_shovels)
+        service_time = truck.truck_capacity / (productivity / n_active)
 
-        productivity = sum(
-            s.shovel_tons / s.shovel_cycle_time
-            for s in ls.shovel_list if not s.repair
-        )
-        productivity = max(productivity, 0.01)
+        # Queue decays as we travel
+        queue_at_arrival = max(0, ls.estimated_queue_wait_time - my_travel)
 
-        # Service time for this truck at one shovel
-        service_time = truck.truck_capacity / (productivity / active_shovels)
+        # Only trucks arriving before us matter
+        _, incoming_cap = self._trucks_arriving_before(mine, ls, LoadSite, my_arrival)
+        incoming_wait = incoming_cap / productivity
 
-        # Queue estimation from the site's parking lot (already computed by framework)
-        queue_wait = ls.estimated_queue_wait_time
+        # Coordination: add virtual load from trucks dispatched in this window
+        coord_cap = self._get_coord_load_ls(ls_idx, now)
+        coord_wait = coord_cap / productivity
 
-        # Additional wait from trucks on road (not yet in queue)
-        road_cap = self._road_trucks_to_load(mine, ls_idx)
-        road_wait = road_cap / productivity
+        return my_travel + queue_at_arrival + incoming_wait + coord_wait + service_time
 
-        # Total estimated time
-        arrival = travel_time
-        queue_done = queue_wait + road_wait
-        wait_on_arrival = max(0, queue_done - arrival)
-
-        return travel_time + wait_on_arrival + service_time
-
-    def _dump_site_score(self, truck, mine, from_ls_idx, ds_idx):
-        """
-        Score a dump site: lower = better.
-        Returns estimated time from departure to finish unloading.
-        """
+    def _dump_site_score(self, truck, mine, ls_idx, ds_idx):
         ds = mine.dump_sites[ds_idx]
+        dist = mine.road.l2d_road_matrix[ls_idx, ds_idx]
         speed = truck.truck_speed
-        dist = mine.road.l2d_road_matrix[from_ls_idx, ds_idx]
-        travel_time = 60.0 * dist / speed
+        my_travel = 60.0 * dist / speed
+        my_arrival = mine.env.now + my_travel
+        now = mine.env.now
 
-        num_dumpers = len(ds.dumper_list)
+        n_dumpers = len(ds.dumper_list)
         dump_time = ds.dumper_list[0].dump_time if ds.dumper_list else 1.0
 
-        queue_wait = ds.estimated_queue_wait_time
-        road_count = self._road_trucks_to_dump(mine, ds_idx)
-        road_wait = (road_count / max(num_dumpers, 1)) * dump_time
+        queue_at_arrival = max(0, ds.estimated_queue_wait_time - my_travel)
 
-        arrival = travel_time
-        queue_done = queue_wait + road_wait
-        wait_on_arrival = max(0, queue_done - arrival)
+        count_before, _ = self._trucks_arriving_before(mine, ds, DumpSite, my_arrival)
+        incoming_wait = (count_before / max(n_dumpers, 1)) * dump_time
 
-        return travel_time + wait_on_arrival + dump_time
+        # Coordination: virtual load from recent dispatches
+        coord_count = self._get_coord_load_ds(ds_idx, now)
+        coord_wait = (coord_count / max(n_dumpers, 1)) * dump_time
 
-    def _best_return_load_time(self, truck, mine, ds_idx):
-        """Estimate the best load site reachable from this dump site."""
+        return my_travel + queue_at_arrival + incoming_wait + coord_wait + dump_time
+
+    def _best_return_time(self, truck, mine, ds_idx):
         best = float('inf')
-        for ls_idx in range(len(mine.load_sites)):
-            dist = mine.road.d2l_road_matrix[ls_idx, ds_idx]
-            score = self._load_site_score(truck, mine, ls_idx, dist)
+        for j in range(len(mine.load_sites)):
+            dist = mine.road.d2l_road_matrix[j, ds_idx]
+            score = self._load_site_score(truck, mine, j, dist)
             if score < best:
                 best = score
         return best
 
     def give_init_order(self, truck: "Truck", mine: "Mine") -> int:
-        """Choose load site with minimum (travel + queue + service) time."""
         best_idx = 0
         best_score = float('inf')
-
-        for ls_idx in range(len(mine.load_sites)):
-            dist = mine.road.charging_to_load[ls_idx]
-            score = self._load_site_score(truck, mine, ls_idx, dist)
+        for j in range(len(mine.load_sites)):
+            dist = mine.road.charging_to_load[j]
+            score = self._load_site_score(truck, mine, j, dist)
             if score < best_score:
                 best_score = score
-                best_idx = ls_idx
-
+                best_idx = j
+        self._record_ls_dispatch(best_idx, truck.truck_capacity, mine.env.now)
         return best_idx
 
     def give_haul_order(self, truck: "Truck", mine: "Mine") -> int:
-        """
-        Choose dump site minimizing (dump_time + alpha * return_time).
-        The return_time term prevents sending trucks to dump sites with
-        terrible return routes, even if the dump itself is fast.
-        """
-        current_location = truck.current_location
-        ls_idx = mine.load_sites.index(current_location)
-
+        ls_idx = mine.load_sites.index(truck.current_location)
         best_idx = 0
         best_score = float('inf')
-
-        for ds_idx in range(len(mine.dump_sites)):
-            dump_score = self._dump_site_score(truck, mine, ls_idx, ds_idx)
-            return_score = self._best_return_load_time(truck, mine, ds_idx)
-            # Weight: dump matters more (immediate), return is discounted
+        for k in range(len(mine.dump_sites)):
+            dump_score = self._dump_site_score(truck, mine, ls_idx, k)
+            return_score = self._best_return_time(truck, mine, k)
             score = dump_score + 0.5 * return_score
             if score < best_score:
                 best_score = score
-                best_idx = ds_idx
-
+                best_idx = k
+        self._record_ds_dispatch(best_idx, mine.env.now)
         return best_idx
 
     def give_back_order(self, truck: "Truck", mine: "Mine") -> int:
-        """Choose load site with minimum (travel + queue + service) time."""
-        current_location = truck.current_location
-        ds_idx = mine.dump_sites.index(current_location)
-
+        ds_idx = mine.dump_sites.index(truck.current_location)
         best_idx = 0
         best_score = float('inf')
-
-        for ls_idx in range(len(mine.load_sites)):
-            dist = mine.road.d2l_road_matrix[ls_idx, ds_idx]
-            score = self._load_site_score(truck, mine, ls_idx, dist)
+        for j in range(len(mine.load_sites)):
+            dist = mine.road.d2l_road_matrix[j, ds_idx]
+            score = self._load_site_score(truck, mine, j, dist)
             if score < best_score:
                 best_score = score
-                best_idx = ls_idx
-
+                best_idx = j
+        self._record_ls_dispatch(best_idx, truck.truck_capacity, mine.env.now)
         return best_idx

--- a/openmines/src/dispatch_algorithms/smart_dispatcher.py
+++ b/openmines/src/dispatch_algorithms/smart_dispatcher.py
@@ -1,16 +1,11 @@
 """
-SmartDispatcher: A full-cycle-aware dynamic dispatch algorithm.
+SmartDispatcher: Enhanced dynamic dispatch based on ShortestTrip.
 
-Key ideas beyond existing algorithms:
-1. Full round-trip lookahead: when choosing a load site, also considers the best
-   dump site reachable from there (and vice versa), optimizing total cycle time.
-2. Capacity-weighted queue estimation: weights incoming trucks by their capacity
-   relative to site productivity, not just count.
-3. Road event awareness: penalizes routes going through jammed/repaired roads.
-4. Multi-shovel parallelism: accounts for the number of available shovels/dumpers
-   to estimate true service throughput.
-5. Adaptive load balancing: combines time-optimal greedy with queue-balancing
-   to prevent starvation of high-productivity sites.
+Improvements over ShortestTripDispatcher:
+1. Dump site selection considers return trip quality (not just dump time)
+2. Separates "trucks on road" from "trucks in queue" to avoid double-counting
+3. Uses individual shovel/dumper availability instead of site-level averages
+4. Accounts for truck capacity differences in queue estimation
 """
 from __future__ import annotations
 import numpy as np
@@ -25,181 +20,152 @@ class SmartDispatcher(BaseDispatcher):
         super().__init__()
         self.name = "SmartDispatcher"
 
-    def _get_road_jam_penalty(self, mine, start, end) -> float:
-        """Estimate extra travel time (minutes) from active jam events on a road."""
-        penalty = 0.0
-        for event_key, event in mine.random_event_pool.event_set.items():
-            if event.event_type == "RoadEvent:jam":
-                info = event.info
-                if (info.get("start_location") == start.name and
-                        info.get("end_location") == end.name):
-                    penalty += info.get("jam_delay", 0.5)
-            elif event.event_type == "RoadEvent:repair":
-                info = event.info
-                if (info.get("start_location") == start.name and
-                        info.get("end_location") == end.name):
-                    penalty += info.get("punish_distance", 0.0) * 60.0 / 25.0  # extra km → minutes
-        return penalty
-
-    def _count_incoming_capacity(self, mine, target, target_type) -> float:
-        """Sum up truck_capacity of all trucks heading to a target location."""
-        total = 0.0
+    def _road_trucks_to_load(self, mine, ls_idx):
+        """Trucks currently on road heading to this load site."""
+        ls = mine.load_sites[ls_idx]
+        total_cap = 0.0
         for t in mine.trucks:
-            if t.target_location is not None and t.status == "moving":
-                if isinstance(t.target_location, target_type):
-                    if t.target_location.name == target.name:
-                        total += t.truck_capacity
-        return total
+            if (t.status == "moving" and t.target_location is not None
+                    and isinstance(t.target_location, LoadSite)
+                    and t.target_location.name == ls.name):
+                total_cap += t.truck_capacity
+        return total_cap
 
-    def _estimate_load_time(self, truck, load_site, mine, from_location, is_charging=False):
+    def _road_trucks_to_dump(self, mine, ds_idx):
+        """Count trucks currently on road heading to this dump site."""
+        ds = mine.dump_sites[ds_idx]
+        count = 0
+        for t in mine.trucks:
+            if (t.status == "moving" and t.target_location is not None
+                    and isinstance(t.target_location, DumpSite)
+                    and t.target_location.name == ds.name):
+                count += 1
+        return count
+
+    def _available_shovels(self, load_site):
+        """Count shovels not under maintenance."""
+        return sum(1 for s in load_site.shovel_list if not s.repair)
+
+    def _load_site_score(self, truck, mine, ls_idx, travel_dist):
         """
-        Estimate total time from current location to load_site, including:
-        - Travel time
-        - Queue wait (capacity-weighted)
-        - Loading service time
+        Score a load site: lower = better.
+        Returns estimated time from departure to finish loading.
         """
-        speed = truck.truck_speed  # km/h
-        now = mine.env.now
-
-        # Travel distance
-        if is_charging:
-            ls_idx = mine.load_sites.index(load_site)
-            dist = mine.road.charging_to_load[ls_idx]
-        elif isinstance(from_location, DumpSite):
-            ds_idx = mine.dump_sites.index(from_location)
-            ls_idx = mine.load_sites.index(load_site)
-            dist = mine.road.d2l_road_matrix[ls_idx, ds_idx]
-        else:
-            ls_idx = mine.load_sites.index(load_site)
-            dist = 0
-
-        travel_time = 60.0 * dist / speed  # minutes
-
-        # Road jam penalty
-        if is_charging:
-            jam_penalty = self._get_road_jam_penalty(mine, mine.charging_site, load_site)
-        elif isinstance(from_location, DumpSite):
-            jam_penalty = self._get_road_jam_penalty(mine, from_location, load_site)
-        else:
-            jam_penalty = 0
-
-        travel_time += jam_penalty
-
-        # Queue estimation: existing queue wait + incoming truck capacity / productivity
-        queue_wait = load_site.estimated_queue_wait_time
-        incoming_cap = self._count_incoming_capacity(mine, load_site, LoadSite)
-        productivity = max(load_site.load_site_productivity, 0.01)
-        num_shovels = max(len(load_site.shovel_list), 1)
-        incoming_wait = incoming_cap / productivity
-
-        # Service time for this truck
-        service_time = truck.truck_capacity / (productivity / num_shovels)
-
-        # Effective wait: max(travel_time, queue_wait + incoming_wait) - travel_time gives wait-on-arrival
-        arrival_time = now + travel_time
-        queue_finish_time = now + queue_wait + incoming_wait
-        effective_wait = max(0, queue_finish_time - arrival_time)
-
-        return travel_time + effective_wait + service_time
-
-    def _estimate_dump_time(self, truck, dump_site, mine, from_load_site):
-        """
-        Estimate total time from a load site to dump_site, including:
-        - Travel time
-        - Queue wait
-        - Unloading time
-        """
+        ls = mine.load_sites[ls_idx]
         speed = truck.truck_speed
-        now = mine.env.now
+        travel_time = 60.0 * travel_dist / speed
 
-        ls_idx = mine.load_sites.index(from_load_site)
-        ds_idx = mine.dump_sites.index(dump_site)
-        dist = mine.road.l2d_road_matrix[ls_idx, ds_idx]
+        # Productivity: only count non-broken shovels
+        active_shovels = self._available_shovels(ls)
+        if active_shovels == 0:
+            return float('inf')  # site is down
+
+        productivity = sum(
+            s.shovel_tons / s.shovel_cycle_time
+            for s in ls.shovel_list if not s.repair
+        )
+        productivity = max(productivity, 0.01)
+
+        # Service time for this truck at one shovel
+        service_time = truck.truck_capacity / (productivity / active_shovels)
+
+        # Queue estimation from the site's parking lot (already computed by framework)
+        queue_wait = ls.estimated_queue_wait_time
+
+        # Additional wait from trucks on road (not yet in queue)
+        road_cap = self._road_trucks_to_load(mine, ls_idx)
+        road_wait = road_cap / productivity
+
+        # Total estimated time
+        arrival = travel_time
+        queue_done = queue_wait + road_wait
+        wait_on_arrival = max(0, queue_done - arrival)
+
+        return travel_time + wait_on_arrival + service_time
+
+    def _dump_site_score(self, truck, mine, from_ls_idx, ds_idx):
+        """
+        Score a dump site: lower = better.
+        Returns estimated time from departure to finish unloading.
+        """
+        ds = mine.dump_sites[ds_idx]
+        speed = truck.truck_speed
+        dist = mine.road.l2d_road_matrix[from_ls_idx, ds_idx]
         travel_time = 60.0 * dist / speed
 
-        # Road jam penalty
-        jam_penalty = self._get_road_jam_penalty(mine, from_load_site, dump_site)
-        travel_time += jam_penalty
+        num_dumpers = len(ds.dumper_list)
+        dump_time = ds.dumper_list[0].dump_time if ds.dumper_list else 1.0
 
-        # Queue estimation
-        queue_wait = dump_site.estimated_queue_wait_time
-        incoming_count = sum(
-            1 for t in mine.trucks
-            if t.target_location is not None and t.status == "moving"
-            and isinstance(t.target_location, DumpSite)
-            and t.target_location.name == dump_site.name
-        )
-        num_dumpers = max(len(dump_site.dumper_list), 1)
-        dump_time = dump_site.dumper_list[0].dump_time if dump_site.dumper_list else 1.0
-        incoming_wait = (incoming_count / num_dumpers) * dump_time
+        queue_wait = ds.estimated_queue_wait_time
+        road_count = self._road_trucks_to_dump(mine, ds_idx)
+        road_wait = (road_count / max(num_dumpers, 1)) * dump_time
 
-        arrival_time = now + travel_time
-        queue_finish_time = now + queue_wait + incoming_wait
-        effective_wait = max(0, queue_finish_time - arrival_time)
+        arrival = travel_time
+        queue_done = queue_wait + road_wait
+        wait_on_arrival = max(0, queue_done - arrival)
 
-        return travel_time + effective_wait + dump_time
+        return travel_time + wait_on_arrival + dump_time
 
-    def _best_dump_time_for_load_site(self, truck, load_site, mine):
-        """Find the minimum dump time from a load site across all dump sites."""
+    def _best_return_load_time(self, truck, mine, ds_idx):
+        """Estimate the best load site reachable from this dump site."""
         best = float('inf')
-        for ds in mine.dump_sites:
-            t = self._estimate_dump_time(truck, ds, mine, load_site)
-            if t < best:
-                best = t
-        return best
-
-    def _best_load_time_for_dump_site(self, truck, dump_site, mine):
-        """Find the minimum load time from a dump site across all load sites."""
-        best = float('inf')
-        for ls in mine.load_sites:
-            t = self._estimate_load_time(truck, ls, mine, dump_site)
-            if t < best:
-                best = t
+        for ls_idx in range(len(mine.load_sites)):
+            dist = mine.road.d2l_road_matrix[ls_idx, ds_idx]
+            score = self._load_site_score(truck, mine, ls_idx, dist)
+            if score < best:
+                best = score
         return best
 
     def give_init_order(self, truck: "Truck", mine: "Mine") -> int:
-        """Choose load site minimizing (travel + wait + load + best_dump_time)."""
+        """Choose load site with minimum (travel + queue + service) time."""
         best_idx = 0
         best_score = float('inf')
 
-        for i, ls in enumerate(mine.load_sites):
-            load_time = self._estimate_load_time(truck, ls, mine, None, is_charging=True)
-            dump_time = self._best_dump_time_for_load_site(truck, ls, mine)
-            score = load_time + dump_time
+        for ls_idx in range(len(mine.load_sites)):
+            dist = mine.road.charging_to_load[ls_idx]
+            score = self._load_site_score(truck, mine, ls_idx, dist)
             if score < best_score:
                 best_score = score
-                best_idx = i
+                best_idx = ls_idx
 
         return best_idx
 
     def give_haul_order(self, truck: "Truck", mine: "Mine") -> int:
-        """Choose dump site minimizing (travel + wait + dump + best_return_load_time)."""
+        """
+        Choose dump site minimizing (dump_time + alpha * return_time).
+        The return_time term prevents sending trucks to dump sites with
+        terrible return routes, even if the dump itself is fast.
+        """
         current_location = truck.current_location
+        ls_idx = mine.load_sites.index(current_location)
+
         best_idx = 0
         best_score = float('inf')
 
-        for i, ds in enumerate(mine.dump_sites):
-            dump_time = self._estimate_dump_time(truck, ds, mine, current_location)
-            return_time = self._best_load_time_for_dump_site(truck, ds, mine)
-            score = dump_time + return_time
+        for ds_idx in range(len(mine.dump_sites)):
+            dump_score = self._dump_site_score(truck, mine, ls_idx, ds_idx)
+            return_score = self._best_return_load_time(truck, mine, ds_idx)
+            # Weight: dump matters more (immediate), return is discounted
+            score = dump_score + 0.5 * return_score
             if score < best_score:
                 best_score = score
-                best_idx = i
+                best_idx = ds_idx
 
         return best_idx
 
     def give_back_order(self, truck: "Truck", mine: "Mine") -> int:
-        """Choose load site minimizing (travel + wait + load + best_dump_time)."""
+        """Choose load site with minimum (travel + queue + service) time."""
         current_location = truck.current_location
+        ds_idx = mine.dump_sites.index(current_location)
+
         best_idx = 0
         best_score = float('inf')
 
-        for i, ls in enumerate(mine.load_sites):
-            load_time = self._estimate_load_time(truck, ls, mine, current_location)
-            dump_time = self._best_dump_time_for_load_site(truck, ls, mine)
-            score = load_time + dump_time
+        for ls_idx in range(len(mine.load_sites)):
+            dist = mine.road.d2l_road_matrix[ls_idx, ds_idx]
+            score = self._load_site_score(truck, mine, ls_idx, dist)
             if score < best_score:
                 best_score = score
-                best_idx = i
+                best_idx = ls_idx
 
         return best_idx


### PR DESCRIPTION
## Summary

Adds 4 new high-performance dispatch algorithms, all significantly outperforming existing dispatchers:

| Algorithm | Approach | Key Idea |
|---|---|---|
| **LPDispatcher** | Linear Programming + dynamic dispatch | LP-optimal steady-state allocation with queue-aware online execution |
| **MPCDispatcher** | Model Predictive Control | Short-horizon assignment using real-time system snapshot (lowest variance) |
| **DualLPDispatcher** | LP + shadow prices + regret tracking | Uses LP dual variables to value marginal capacity; regret-based dynamic bias |
| **SmartDispatcher** | Dynamic queue-aware heuristic | Precise queue estimation + return-trip aware dump selection |

## Benchmark (north_pit_mine.json, 71 trucks, 240 min, 20 runs)

| Rank | Dispatcher | Mean (tons) | Std | vs Previous SOTA |
|---:|---|---:|---:|---|
| **1** | **LPDispatcher** | **11050** | 664 | **+15.3%** |
| **2** | **MPCDispatcher** | **10974** | **548** | +14.5% |
| **3** | **DualLPDispatcher** | **10946** | 821 | +14.2% |
| **4** | **SmartDispatcher** | **10732** | 463 | +12.0% |
| 5 | ShortestTripDispatcher | 9583 | 665 | baseline |
| 6 | SPTFDispatcher | 9065 | 246 | -5.4% |
| 7 | SQDispatcher | 8931 | 300 | -6.8% |
| 8 | RandomDispatcher | 8109 | 316 | -15.4% |
| 9 | FixedGroupDispatcher | 7346 | 188 | -23.3% |
| 10 | NearestDispatcher | 6752 | 398 | -29.5% |
| 11 | NaiveDispatcher | 1883 | 138 | -80.4% |

## Algorithm Details

### LPDispatcher (BEST mean)
- Solves LP maximizing total throughput s.t. shovel productivity and dumper capacity constraints (scipy HiGHS)
- Re-solves every 15 min to adapt to breakdowns/road events
- Online dispatch uses dynamic queue estimation biased 30% toward LP targets
- Only needs scipy (already a dependency)

### MPCDispatcher (BEST stability)
- Takes real-time system snapshot at each decision (trucks on roads, queue states, maintenance)
- Step-level assignment tracking prevents burst congestion (multiple trucks → same site)
- No LP solve needed — purely reactive to current state
- Lowest variance (548) among top performers

### DualLPDispatcher (experimental)
- Extracts shadow prices from LP dual variables to penalize binding constraints
- Regret tracking: dynamically adjusts dispatch bias based on actual vs target allocation
- Shadow prices add noise for this problem — works better when constraints are more varied

### SmartDispatcher (best heuristic)
- Separates road-truck vs queue-truck estimation (avoids double-counting in ShortestTrip)
- Shovel maintenance awareness
- Return-trip weighted dump selection: `score = dump + 0.5 * return`

## Dependencies
- All 4 algorithms only require `numpy` and `scipy` (both already in requirements.txt)
- No external solvers (Gurobi, etc.) needed

## Test Plan
- [x] Full benchmark: 11 dispatchers × 20 runs each
- [x] LP parameter tuning: bias=[0.0-0.30], interval=[15,30,60]
- [x] MPC return-trip weight sensitivity
- [x] Verified no new dependencies

https://claude.ai/code/session_01778peCkoK14CzU2ZpD6R5r